### PR TITLE
Remove dependency on commons-lang

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,11 +53,6 @@
             <version>${jackson.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-lang3</artifactId>
-            <version>3.4</version>
-        </dependency>
-        <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
             <version>18.0</version>

--- a/src/main/java/com/yahoo/ycb/Configuration.java
+++ b/src/main/java/com/yahoo/ycb/Configuration.java
@@ -10,7 +10,6 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
 import com.googlecode.concurrentlinkedhashmap.ConcurrentLinkedHashMap;
-import org.apache.commons.lang3.StringUtils;
 
 import java.io.IOException;
 import java.util.*;
@@ -110,11 +109,9 @@ public class Configuration {
     }
 
     private static String contextToString(final Map<String, String> context) {
-        return StringUtils.join(
-                context.keySet().stream().sorted()
-                        .map(key -> key + "=" + context.get(key)
-                        ).collect(Collectors.toList()),
-                "&");
+        return context.entrySet().stream().sorted()
+                .map(entry -> entry.getKey() + "=" + entry.getValue())
+                .collect(Collectors.joining("&"));
     }
 
     /**

--- a/src/main/java/com/yahoo/ycb/Configuration.java
+++ b/src/main/java/com/yahoo/ycb/Configuration.java
@@ -109,8 +109,9 @@ public class Configuration {
     }
 
     private static String contextToString(final Map<String, String> context) {
-        return context.entrySet().stream().sorted()
+        return context.entrySet().stream()
                 .map(entry -> entry.getKey() + "=" + entry.getValue())
+                .sorted()
                 .collect(Collectors.joining("&"));
     }
 


### PR DESCRIPTION
Join is supported in Java 8 collector. One less dependency to deal with.