### PR TITLE
Fixes bug when the fixed context is total

### DIFF
--- a/src/main/java/com/yahoo/ycb/LookupTree.java
+++ b/src/main/java/com/yahoo/ycb/LookupTree.java
@@ -32,7 +32,17 @@ abstract class LookupTree {
      * @return The Lookup Tree
      */
     public static LookupTree create(final List<Dimension> dimensions, Set<Bundle> bundles, final Map<String, String> fixedContext) {
-        final LookupTree node = new InnerNode();
+        // drop dimensions present in the fixed context (so we have a shallower tree).
+        final List<Dimension> actualDimensions = new ArrayList<>();
+        dimensions.forEach(
+                dimension -> {
+                    if (!fixedContext.containsKey(dimension.getName())) {
+                        actualDimensions.add(dimension);
+                    }
+                });
+
+        // if the dimensions are empty, create a leaf node
+        final LookupTree node = actualDimensions.isEmpty() ? new LeafNode() : new InnerNode();
 
         bundles.stream()
                 // make sure we are inserting in the correct order (more generic first, more specific after).
@@ -42,16 +52,6 @@ abstract class LookupTree {
                         // only insert bundles which are compatible with fixed context
                 .filter(bundle -> fixedContextMatch(dimensions, fixedContext, bundle.getContext()))
                 .forEach(bundle -> {
-
-                    // drop dimensions present in the fixed context (so we have a shallower tree).
-                    final List<Dimension> actualDimensions = new ArrayList<>();
-                    dimensions.forEach(
-                            dimension -> {
-                                if (!fixedContext.containsKey(dimension.getName())) {
-                                    actualDimensions.add(dimension);
-                                }
-                            });
-
                     // insert (with drop dimensions) the bundle in the tree node
                     node.insert(actualDimensions, bundle.getContext(), bundle.getDelta());
                 });

--- a/src/test/java/com/yahoo/ycb/ConfigurationTest.java
+++ b/src/test/java/com/yahoo/ycb/ConfigurationTest.java
@@ -115,6 +115,30 @@ public class ConfigurationTest {
         assertEquals("www.example-bucket_006-dev.com", projection.getText("service_x.api_config.endpoint"));
     }
 
+
+    @Test
+    public void testTotalFixedContext() throws IOException {
+        Loader loader = getLoader("example1");
+
+        Map<String, String> fixedContext = new HashMap<>();
+        fixedContext.put("environment", "dev");
+        fixedContext.put("bucket", "BUCKET_002");
+        fixedContext.put("network", "internal");
+        fixedContext.put("user_type", "premium");
+        fixedContext.put("locale", "en-US");
+
+        Configuration configuration = Configuration.load(loader, fixedContext);
+
+        HashMap<String, String> context = new HashMap<>();
+
+        Configuration.Projection projection = configuration.project(context);
+
+        assertEquals("www.service_y.com", projection.getText("service_y.hostname"));
+        assertEquals("no", projection.getText("service_y.modules.generic"));
+        assertEquals("GET", projection.getText("routes.main_route.method"));
+        assertEquals("www.example-dev.com", projection.getText("service_x.api_config.endpoint"));
+    }
+
     @Test
     public void testDifferentPathSeparator() throws IOException {
         Loader loader = getLoader("example1");


### PR DESCRIPTION
When the fixedContext sets values for **all** the existing dimensions, there was a bug because the code was assuming the first lookup tree node would be an internal node, but if fact it should be a leaf node.