### PR TITLE
implements Configuration::validate

### DIFF
--- a/src/main/java/com/yahoo/ycb/Configuration.java
+++ b/src/main/java/com/yahoo/ycb/Configuration.java
@@ -41,6 +41,15 @@ public class Configuration {
     }
 
     /**
+     * Perform some validations in the configuration
+     *
+     * @return A List of errors in the configuration, empty list for no errors
+     */
+    public List<ValidationError> validate() {
+        return tree.validate();
+    }
+
+    /**
      * Construct the configuration given a Loader.
      *
      * @param loader The loader is responsible for providing the raw configuration values from somewhere

--- a/src/main/java/com/yahoo/ycb/InnerNode.java
+++ b/src/main/java/com/yahoo/ycb/InnerNode.java
@@ -11,11 +11,25 @@ import com.fasterxml.jackson.databind.node.NullNode;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 class InnerNode extends LookupTree {
 
     private Dimension dimension;
     private final Map<String, LookupTree> edges = new HashMap<>();
+
+    /**
+     * @return A list of leaf children of this Node
+     */
+    @Override
+    protected List<PathLeaf> traverse() {
+        return edges.entrySet().stream()
+                .flatMap(entry -> entry.getValue().traverse().stream()
+                        .map(pathLeaf -> new PathLeaf(pathLeaf, entry.getKey())))
+                .collect(Collectors.toList());
+    }
 
     @Override
     public JsonNode project(Map<String, String> context, String[] path) {

--- a/src/main/java/com/yahoo/ycb/LeafNode.java
+++ b/src/main/java/com/yahoo/ycb/LeafNode.java
@@ -7,13 +7,21 @@ package com.yahoo.ycb;
 
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.google.common.collect.Lists;
 
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 class LeafNode extends LookupTree {
 
     private JsonNode delta;
+
+    /**
+     * @return A list of leaf children of this Node
+     */
+    @Override
+    protected List<PathLeaf> traverse() {
+        return Collections.singletonList(new PathLeaf(delta));
+    }
 
     @Override
     public JsonNode project(Map<String, String> context, String[] path) {

--- a/src/main/java/com/yahoo/ycb/ValidationError.java
+++ b/src/main/java/com/yahoo/ycb/ValidationError.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2016 Yahoo inc.
+ * Licensed under the terms of the BSD License. Please see LICENSE file in the project home directory for terms.
+ */
+package com.yahoo.ycb;
+
+
+import java.util.List;
+
+public class ValidationError {
+    private final List<String> path;
+    private final Reason reason;
+    private final List<String> contextValues;
+
+    public ValidationError(List<String> path, Reason reason, List<String> contextValues) {
+        this.path = path;
+        this.reason = reason;
+        this.contextValues = contextValues;
+    }
+
+    public List<String> getPath() {
+        return path;
+    }
+
+    public Reason getReason() {
+        return reason;
+    }
+
+    public List<String> getContextValues() {
+        return contextValues;
+    }
+
+    @Override
+    public String toString() {
+        return "context=(" + String.join(", ", contextValues) + "), path=" + String.join(".", path) + ": " + reason;
+    }
+
+    public enum Reason {
+        MISSING_MASTER_PROPERTY,
+        REPLACING_DIFFERENT_TYPES;
+
+        @Override
+        public String toString() {
+            switch (this) {
+                case MISSING_MASTER_PROPERTY: return "missing property in master";
+                case REPLACING_DIFFERENT_TYPES: return "property being replaced with different type";
+            }
+            return "invalid";
+        }
+    }
+}

--- a/src/test/java/com/yahoo/ycb/ValidationTest.java
+++ b/src/test/java/com/yahoo/ycb/ValidationTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2016 Yahoo inc.
+ * Licensed under the terms of the BSD License. Please see LICENSE file in the project home directory for terms.
+ */
+package com.yahoo.ycb;
+
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URL;
+import java.util.List;
+
+import static junit.framework.Assert.*;
+
+public class ValidationTest {
+
+
+    private static Loader getLoader(String name) {
+        final URL url = Thread.currentThread().getContextClassLoader().getResource(name);
+        assert url != null;
+
+        return new FileSystemLoader(new File(url.getPath()));
+    }
+
+    @Test
+    public void testIsValid() throws IOException {
+        Loader loader = getLoader("example2");
+
+        Configuration configuration = Configuration.load(loader);
+
+        List<ValidationError> errors = configuration.validate();
+
+        assertNotNull(errors);
+        assertTrue(errors.isEmpty());
+    }
+
+    @Test
+    public void testIsNotValid() throws IOException {
+        Loader loader = getLoader("example3");
+
+        Configuration configuration = Configuration.load(loader);
+
+        List<ValidationError> errors = configuration.validate();
+
+        assertNotNull(errors);
+        assertFalse(errors.isEmpty());
+
+        assertEquals(errors.size(), 2);
+
+        assertEquals(errors.get(0).getReason(), ValidationError.Reason.MISSING_MASTER_PROPERTY);
+        assertEquals(errors.get(0).getPath().size(), 2);
+        assertEquals(errors.get(0).getPath().get(0), "maestro");
+        assertEquals(errors.get(0).getPath().get(1), "enabled_xx");
+
+        assertEquals(errors.get(0).getContextValues().size(), 4);
+        assertEquals(errors.get(0).getContextValues().get(0), "*");
+        assertEquals(errors.get(0).getContextValues().get(1), "external");
+        assertEquals(errors.get(0).getContextValues().get(2), "*");
+        assertEquals(errors.get(0).getContextValues().get(3), "production");
+
+
+        assertEquals(errors.get(1).getReason(), ValidationError.Reason.REPLACING_DIFFERENT_TYPES);
+        assertEquals(errors.get(1).getPath().size(), 2);
+        assertEquals(errors.get(1).getPath().get(0), "maestro");
+        assertEquals(errors.get(1).getPath().get(1), "enable_debug");
+
+        assertEquals(errors.get(1).getContextValues().size(), 4);
+        assertEquals(errors.get(1).getContextValues().get(0), "*");
+        assertEquals(errors.get(1).getContextValues().get(1), "*");
+        assertEquals(errors.get(1).getContextValues().get(2), "*");
+        assertEquals(errors.get(1).getContextValues().get(3), "production");
+    }
+}

--- a/src/test/resources/example3/dimensions.yml
+++ b/src/test/resources/example3/dimensions.yml
@@ -1,0 +1,20 @@
+# Copyright 2015 Yahoo inc.
+# Licensed under the terms of the BSD License. Please see LICENSE file in the project home directory for terms.
+
+- dimensions:
+    -
+        environment:
+           stage:
+           production:
+    -
+        cluster:
+            west:
+            east:
+    -
+        network:
+            external:
+            internal:
+    -
+        bucket:
+            BUCKET_A:
+                BUCKET_AB:

--- a/src/test/resources/example3/settings.yml
+++ b/src/test/resources/example3/settings.yml
@@ -1,0 +1,30 @@
+# Copyright 2016 Yahoo inc.
+# Licensed under the terms of the BSD License. Please see LICENSE file in the project home directory for terms.
+
+- settings: {}
+
+  maestro:
+
+    enable_stack_traces: true
+    enable_debug:        true
+
+    enable_super_new_api: true
+
+
+- settings: {network: external, environment: production}
+
+  maestro:
+    enable_stack_traces: false
+    enable_debug:        false
+
+    # property not defined in master!
+    enabled_xx:          true
+
+
+- settings: {environment: production}
+
+  maestro:
+    enable_super_new_api: false
+
+    # different types!
+    enable_debug:         20


### PR DESCRIPTION
This method will return a list of zero or more ValidationError instances. Currently there is two kinds of validation being performed:

 * bundle is setting a property that is not defined in master.
 * bundle is setting a property with a different type that was defined in master.

This will enforce users of YCB to make sure that master defines the configuration schema, and all overwriting rules have to conform to the types and not add unanticipated configurations.

For usage, see the new test (ValidationTest)