### PR TITLE
Add a flag to allow system properties override fix #7

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,13 @@ projection.getBoolean("feature_x.enabled") // true
 
 Please check out the unit tests for more comprehensive use cases.
 
+## System Property Override
+
+The project API accepts a flag in which that the configuration can be override by JVM System
+properties. That feature is useful if one wants to override specific configuration properties
+in a particular running instance of the application, by simply setting properties in the java
+command line (like `java -Dmyapp.foo.bar=10`).
+
 ## License
 
 Code licensed under the BSD license.  See LICENSE file for terms.

--- a/src/test/java/com/yahoo/ycb/SystemPropertyOverrideTest.java
+++ b/src/test/java/com/yahoo/ycb/SystemPropertyOverrideTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2016 Yahoo inc.
+ * Licensed under the terms of the BSD License. Please see LICENSE file in the project home directory for terms.
+ */
+package com.yahoo.ycb;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URL;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static junit.framework.Assert.*;
+import static org.junit.Assert.assertEquals;
+
+public class SystemPropertyOverrideTest {
+
+
+    private static Loader getLoader(String name) {
+        final URL url = Thread.currentThread().getContextClassLoader().getResource(name);
+        assert url != null;
+
+        return new FileSystemLoader(new File(url.getPath()));
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        System.clearProperty("routes.main_route.method");
+        System.clearProperty("service_x.api_config.endpoint");
+    }
+
+    @Test
+    public void testDontOverride() throws IOException {
+        Loader loader = getLoader("example1");
+
+        Map<String, String> fixedContext = new HashMap<>();
+        fixedContext.put("environment", "dev");
+        fixedContext.put("network", "internal");
+
+        Configuration configuration = Configuration.load(loader, fixedContext);
+
+        HashMap<String, String> context = new HashMap<>();
+
+        Configuration.Projection projection = configuration.project(context);
+
+        assertEquals("GET", projection.getText("routes.main_route.method"));
+
+        System.setProperty("routes.main_route.method", "PUT");
+
+        // continued unchanged
+        assertEquals("GET", projection.getText("routes.main_route.method"));
+
+        assertEquals("www.example-dev.com", projection.getText("service_x.api_config.endpoint"));
+    }
+
+    @Test
+    public void testMustOverride() throws IOException {
+        Loader loader = getLoader("example1");
+
+        Map<String, String> fixedContext = new HashMap<>();
+        fixedContext.put("environment", "dev");
+        fixedContext.put("network", "internal");
+
+        Configuration configuration = Configuration.load(loader, fixedContext);
+
+        HashMap<String, String> context = new HashMap<>();
+
+        Configuration.Projection projection = configuration.project(context, true);
+
+        assertEquals("GET", projection.getText("routes.main_route.method"));
+
+        System.setProperty("routes.main_route.method", "PUT");
+
+        // must have unchanged
+        assertEquals("PUT", projection.getText("routes.main_route.method"));
+
+        assertEquals(58741503419348L, projection.getLong("crumb.limit"));
+
+        System.setProperty("crumb.limit", "123871");
+
+        // must have unchanged
+        assertEquals(123871, projection.getLong("crumb.limit"));
+
+        assertEquals("www.example-dev.com", projection.getText("service_x.api_config.endpoint"));
+    }
+}


### PR DESCRIPTION
Either in the command line (e.g. `java -Dmyapp.foo.bar=10`) or programmatically (i.e. `Java.setProperty`) one can override configuration keys.