### PR TITLE
Validate dimension values in configuration bundles

### DIFF
--- a/src/main/java/com/yahoo/ycb/LookupTree.java
+++ b/src/main/java/com/yahoo/ycb/LookupTree.java
@@ -34,6 +34,8 @@ abstract class LookupTree {
      * @return The Lookup Tree
      */
     public static LookupTree create(final List<Dimension> dimensions, Set<Bundle> bundles, final Map<String, String> fixedContext) {
+        validateBundles(dimensions, bundles);
+
         // drop dimensions present in the fixed context (so we have a shallower tree).
         final List<Dimension> actualDimensions = new ArrayList<>();
         dimensions.forEach(
@@ -59,6 +61,22 @@ abstract class LookupTree {
                 });
 
         return node;
+    }
+
+    private static void validateBundles(final List<Dimension> dimensions, final Set<Bundle> bundles) {
+        final Map<String, List<String>> dimensionValues = dimensions.stream()
+            .collect(Collectors.toMap(Dimension::getName, Dimension::traverse));
+
+        bundles.forEach(bundle ->
+            bundle.getContext().forEach((dimension, value) -> {
+                if (!dimensionValues.containsKey(dimension)) {
+                    throw new IllegalArgumentException("Unknown dimension: " + dimension);
+                }
+                if (!dimensionValues.get(dimension).contains(value)) {
+                    throw new IllegalArgumentException("Invalid value for dimension: " + dimension + " -> " + value);
+                }
+            })
+        );
     }
 
     private static boolean fixedContextMatch(List<Dimension> dimensions, final Map<String, String> fixedContext, Map<String, String> bundleContext) {

--- a/src/test/java/com/yahoo/ycb/ConfigurationTest.java
+++ b/src/test/java/com/yahoo/ycb/ConfigurationTest.java
@@ -18,16 +18,9 @@ import static org.junit.Assert.*;
 
 public class ConfigurationTest {
 
-    private static Loader getLoader(String name) {
-        final URL url = Thread.currentThread().getContextClassLoader().getResource(name);
-        assert url != null;
-
-        return new FileSystemLoader(new File(url.getPath()));
-    }
-
     @Test
     public void testConfiguration() throws IOException {
-        Loader loader = getLoader("example1");
+        Loader loader = TestUtils.getLoader("example1");
 
         Configuration configuration = Configuration.load(loader);
 
@@ -85,7 +78,7 @@ public class ConfigurationTest {
 
     @Test
     public void testFixedContext() throws IOException {
-        Loader loader = getLoader("example1");
+        Loader loader = TestUtils.getLoader("example1");
 
         Map<String, String> fixedContext = new HashMap<>();
         fixedContext.put("environment", "dev");
@@ -118,7 +111,7 @@ public class ConfigurationTest {
 
     @Test
     public void testTotalFixedContext() throws IOException {
-        Loader loader = getLoader("example1");
+        Loader loader = TestUtils.getLoader("example1");
 
         Map<String, String> fixedContext = new HashMap<>();
         fixedContext.put("environment", "dev");
@@ -141,7 +134,7 @@ public class ConfigurationTest {
 
     @Test
     public void testDifferentPathSeparator() throws IOException {
-        Loader loader = getLoader("example1");
+        Loader loader = TestUtils.getLoader("example1");
 
         Configuration configuration = Configuration.load(loader);
         configuration.setPathSeparator("\\/");
@@ -163,7 +156,7 @@ public class ConfigurationTest {
 
     @Test
     public void testGetList() throws IOException {
-        Loader loader = getLoader("example1");
+        Loader loader = TestUtils.getLoader("example1");
 
         Configuration configuration = Configuration.load(loader);
 
@@ -185,7 +178,7 @@ public class ConfigurationTest {
 
     @Test
     public void testGetObject() throws IOException {
-        Loader loader = getLoader("example1");
+        Loader loader = TestUtils.getLoader("example1");
 
         Configuration configuration = Configuration.load(loader);
 
@@ -204,7 +197,7 @@ public class ConfigurationTest {
 
     @Test
     public void testGetSimpleTypes() throws IOException {
-        Loader loader = getLoader("example1");
+        Loader loader = TestUtils.getLoader("example1");
 
         Configuration configuration = Configuration.load(loader);
 
@@ -220,7 +213,7 @@ public class ConfigurationTest {
 
     @Test
     public void testTraverseContext() throws IOException {
-        Loader loader = getLoader("example2");
+        Loader loader = TestUtils.getLoader("example2");
 
         Configuration configuration = Configuration.load(loader);
 

--- a/src/test/java/com/yahoo/ycb/LookupTreeTest.java
+++ b/src/test/java/com/yahoo/ycb/LookupTreeTest.java
@@ -14,16 +14,9 @@ import java.net.URL;
 
 public class LookupTreeTest {
 
-    private static Loader getLoader(String name) {
-        final URL url = Thread.currentThread().getContextClassLoader().getResource(name);
-        assert url != null;
-
-        return new FileSystemLoader(new File(url.getPath()));
-    }
-
     @Test
     public void testUnknownDimension() throws IOException {
-        Loader loader = getLoader("unknownDimension");
+        Loader loader = TestUtils.getLoader("unknownDimension");
 
         try {
             Configuration.load(loader);
@@ -34,7 +27,7 @@ public class LookupTreeTest {
 
     @Test
     public void testInvalidValue() throws IOException {
-        Loader loader = getLoader("invalidDimension");
+        Loader loader = TestUtils.getLoader("invalidDimension");
 
         try {
             Configuration.load(loader);

--- a/src/test/java/com/yahoo/ycb/LookupTreeTest.java
+++ b/src/test/java/com/yahoo/ycb/LookupTreeTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2016 Yahoo inc.
+ * Licensed under the terms of the BSD License. Please see LICENSE file in the project home directory for terms.
+ */
+
+package com.yahoo.ycb;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URL;
+
+public class LookupTreeTest {
+
+    private static Loader getLoader(String name) {
+        final URL url = Thread.currentThread().getContextClassLoader().getResource(name);
+        assert url != null;
+
+        return new FileSystemLoader(new File(url.getPath()));
+    }
+
+    @Test
+    public void testUnknownDimension() throws IOException {
+        Loader loader = getLoader("unknownDimension");
+
+        try {
+            Configuration.load(loader);
+            Assert.fail("Expecting IllegalArgumentException to be thrown for an unknown dimension");
+        }
+        catch (IllegalArgumentException e) {}
+    }
+
+    @Test
+    public void testInvalidValue() throws IOException {
+        Loader loader = getLoader("invalidDimension");
+
+        try {
+            Configuration.load(loader);
+            Assert.fail("Expecting IllegalArgumentException to be thrown for an invalid dimension value");
+        }
+        catch (IllegalArgumentException e) {}
+    }
+
+}

--- a/src/test/java/com/yahoo/ycb/SystemPropertyOverrideTest.java
+++ b/src/test/java/com/yahoo/ycb/SystemPropertyOverrideTest.java
@@ -19,14 +19,6 @@ import static org.junit.Assert.assertEquals;
 
 public class SystemPropertyOverrideTest {
 
-
-    private static Loader getLoader(String name) {
-        final URL url = Thread.currentThread().getContextClassLoader().getResource(name);
-        assert url != null;
-
-        return new FileSystemLoader(new File(url.getPath()));
-    }
-
     @Before
     public void setUp() throws Exception {
         System.clearProperty("routes.main_route.method");
@@ -35,7 +27,7 @@ public class SystemPropertyOverrideTest {
 
     @Test
     public void testDontOverride() throws IOException {
-        Loader loader = getLoader("example1");
+        Loader loader = TestUtils.getLoader("example1");
 
         Map<String, String> fixedContext = new HashMap<>();
         fixedContext.put("environment", "dev");
@@ -59,7 +51,7 @@ public class SystemPropertyOverrideTest {
 
     @Test
     public void testMustOverride() throws IOException {
-        Loader loader = getLoader("example1");
+        Loader loader = TestUtils.getLoader("example1");
 
         Map<String, String> fixedContext = new HashMap<>();
         fixedContext.put("environment", "dev");

--- a/src/test/java/com/yahoo/ycb/TestUtils.java
+++ b/src/test/java/com/yahoo/ycb/TestUtils.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2016 Yahoo inc.
+ * Licensed under the terms of the BSD License. Please see LICENSE file in the project home directory for terms.
+ */
+
+package com.yahoo.ycb;
+
+import java.io.File;
+import java.net.URL;
+
+public class TestUtils {
+    public static Loader getLoader(String name) {
+        final URL url = Thread.currentThread().getContextClassLoader().getResource(name);
+        assert url != null;
+
+        return new FileSystemLoader(new File(url.getPath()));
+    }
+}

--- a/src/test/java/com/yahoo/ycb/ValidationTest.java
+++ b/src/test/java/com/yahoo/ycb/ValidationTest.java
@@ -15,17 +15,9 @@ import static junit.framework.Assert.*;
 
 public class ValidationTest {
 
-
-    private static Loader getLoader(String name) {
-        final URL url = Thread.currentThread().getContextClassLoader().getResource(name);
-        assert url != null;
-
-        return new FileSystemLoader(new File(url.getPath()));
-    }
-
     @Test
     public void testIsValid() throws IOException {
-        Loader loader = getLoader("example2");
+        Loader loader = TestUtils.getLoader("example2");
 
         Configuration configuration = Configuration.load(loader);
 
@@ -37,7 +29,7 @@ public class ValidationTest {
 
     @Test
     public void testIsNotValid() throws IOException {
-        Loader loader = getLoader("example3");
+        Loader loader = TestUtils.getLoader("example3");
 
         Configuration configuration = Configuration.load(loader);
 

--- a/src/test/resources/invalidDimension/dimensions.yml
+++ b/src/test/resources/invalidDimension/dimensions.yml
@@ -1,0 +1,8 @@
+# Copyright 2016 Yahoo inc.
+# Licensed under the terms of the BSD License. Please see LICENSE file in the project home directory for terms.
+
+- dimensions:
+    -
+        environment:
+           stage:
+           production:

--- a/src/test/resources/invalidDimension/settings.yml
+++ b/src/test/resources/invalidDimension/settings.yml
@@ -1,0 +1,11 @@
+# Copyright 2016 Yahoo inc.
+# Licensed under the terms of the BSD License. Please see LICENSE file in the project home directory for terms.
+
+- settings: {}
+
+  enable_super_new_api: false
+
+# produktion is an invalid dimension value.
+- settings: {environment: produktion}
+
+  enable_super_new_api: true

--- a/src/test/resources/unknownDimension/dimensions.yml
+++ b/src/test/resources/unknownDimension/dimensions.yml
@@ -1,0 +1,8 @@
+# Copyright 2016 Yahoo inc.
+# Licensed under the terms of the BSD License. Please see LICENSE file in the project home directory for terms.
+
+- dimensions:
+    -
+        environment:
+           stage:
+           production:

--- a/src/test/resources/unknownDimension/settings.yml
+++ b/src/test/resources/unknownDimension/settings.yml
@@ -1,0 +1,15 @@
+# Copyright 2016 Yahoo inc.
+# Licensed under the terms of the BSD License. Please see LICENSE file in the project home directory for terms.
+
+- settings: {}
+
+  enable_super_new_api: false
+
+- settings: {environment: production}
+
+  enable_super_new_api: false
+
+# cluster dimension was not defined.
+- settings: {environment: production, cluster: west}
+
+  enable_super_new_api: true


### PR DESCRIPTION
On my project we recently got bitten by two different user errors that are silently accepted by ycb-java:

* Unknown dimensions: ycb-java silently ignored the unknown dimension, which caused the seemingly more specific context to accidentally overwrite less specific contexts.

* Invalid dimension values: ycb-java silently returned null for all settings in this case. I did not debug this scenario, but I'm assuming somehow the projection was empty.

This PR throws an exception during Configuration creation in either of these scenarios.

This is technically a breaking change, although the value of the original behavior is debatable. If desired, I could move this validation behind a flag to maintain backwards compatibility.