### PR TITLE
[squid:S1118] Utility classes should not have public constructors

### DIFF
--- a/src/main/java/com/yahoo/ycb/LoadUtils.java
+++ b/src/main/java/com/yahoo/ycb/LoadUtils.java
@@ -15,6 +15,9 @@ import java.util.*;
 
 class LoadUtils {
 
+    private LoadUtils() {
+    }
+
     protected static List<Dimension> parseDimensions(JsonNode node) throws IOException {
         if (!node.isArray()) {
             throw new IOException("Expecting array.");

--- a/src/test/java/com/yahoo/ycb/TestUtils.java
+++ b/src/test/java/com/yahoo/ycb/TestUtils.java
@@ -9,6 +9,9 @@ import java.io.File;
 import java.net.URL;
 
 public class TestUtils {
+    private TestUtils() {
+    }
+
     public static Loader getLoader(String name) {
         final URL url = Thread.currentThread().getContextClassLoader().getResource(name);
         assert url != null;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1118 - “Utility classes should not have public constructors ”. 

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1118

Please let me know if you have any questions.
Ayman Abdelghany.